### PR TITLE
Downage categories v1

### DIFF
--- a/app.py
+++ b/app.py
@@ -16,7 +16,7 @@ from .cs411project.views.test_view import TestAPIView, TestPreparedStatementAPIV
 from .cs411project.views.user_view import SpecificUserView, UsersView
 from .cs411project.views.downage_category_view import SimpleDownageCategoryView, \
         SimpleDownageCategoryStartBatchView, MixtureModelDownageCategoryStartBatchView, \
-        MixtureModelDownageCategoryView
+        MixtureModelDownageCategoryView, DownageCategoriesEditingExistingCommentView
 
 # Create flask app
 # TODO: specify static_folder and template_folder in this constructor
@@ -85,6 +85,7 @@ app.add_url_rule('/project/downage-category/simple/startBatch', view_func=Simple
 app.add_url_rule('/project/downage-category/simple', view_func=SimpleDownageCategoryView.as_view('downageCategorySimpleGET'))
 app.add_url_rule('/project/downage-category/mixture/startBatch', view_func=MixtureModelDownageCategoryStartBatchView.as_view('downageCategoryMixtureStartBatch'))
 app.add_url_rule('/project/downage-category/mixture/<int:machine_id>', view_func=MixtureModelDownageCategoryView.as_view('downageCategoryMixtureGET'))
+app.add_url_rule('/project/downage-category/editing-comment/<int:comment_id>', view_func=DownageCategoriesEditingExistingCommentView.as_view('downageCategoryEditingComment'))
 
 # HTML endpoints
 app.add_url_rule('/home', view_func=mainView.as_view('mainPage'))

--- a/app.py
+++ b/app.py
@@ -14,6 +14,9 @@ from .cs411project.views.machine_view import SpecificMachineView, MachinesView
 from .cs411project.views.query_comment import QueryCommentView
 from .cs411project.views.test_view import TestAPIView, TestPreparedStatementAPIView
 from .cs411project.views.user_view import SpecificUserView, UsersView
+from .cs411project.views.downage_category_view import SimpleDownageCategoryView, \
+        SimpleDownageCategoryStartBatchView, MixtureModelDownageCategoryStartBatchView, \
+        MixtureModelDownageCategoryView
 
 # Create flask app
 # TODO: specify static_folder and template_folder in this constructor
@@ -76,6 +79,12 @@ app.add_url_rule('/project/comment/<comment_id>', view_func=CommentView.as_view(
 app.add_url_rule('/project/comment/insert', view_func=CommentView.as_view('comment'))
 app.add_url_rule('/project/comment/update/<CommentID>', view_func=CommentChangeView.as_view('commentChange'))
 app.add_url_rule('/project/comment/delete/<CommentID>', view_func=CommentChangeView.as_view('commentDelete'))
+
+# Downage Category API
+app.add_url_rule('/project/downage-category/simple/startBatch', view_func=SimpleDownageCategoryStartBatchView.as_view('downageCategorySimpleStartBatch'))
+app.add_url_rule('/project/downage-category/simple', view_func=SimpleDownageCategoryView.as_view('downageCategorySimpleGET'))
+app.add_url_rule('/project/downage-category/mixture/startBatch', view_func=MixtureModelDownageCategoryStartBatchView.as_view('downageCategoryMixtureStartBatch'))
+app.add_url_rule('/project/downage-category/mixture/<int:machine_id>', view_func=MixtureModelDownageCategoryView.as_view('downageCategoryMixtureGET'))
 
 # HTML endpoints
 app.add_url_rule('/home', view_func=mainView.as_view('mainPage'))

--- a/cs411project/database/constants.py
+++ b/cs411project/database/constants.py
@@ -2,6 +2,13 @@
 MACHINE_STATUS_BROKEN = 0
 MACHINE_STATUS_ALIVE = 1
 
+# The "prebaked" downage categories
+PREBAKED_DOWNAGE_CATEGORY_TEXTS = [
+    'Software Problem',
+    'Hardware Problem',
+    'Machine Problem'
+]
+
 # TODO: remove this and actually query locations after basic demo
 # x should be within [0-3] and y should be within [0-8]
 STUB_LOCATION_DICT = {

--- a/cs411project/nlp/downage_categories.py
+++ b/cs411project/nlp/downage_categories.py
@@ -1,0 +1,150 @@
+import numpy as np
+
+class DownageCategories:
+
+    @classmethod
+    def calculate_word_probabilities(cls, bow_corpus, id2token, mu=0.001):
+        """Calculate word probabilities for an entire corpus
+        
+            Parameters:
+                bow_corpus: The corpus as in BOW form (list of lists)
+                id2token: A Python dictionary mapping a BOW id to a token
+                mu: (optional) Smoothing parameter for additive smoothing
+                
+            Returns:
+                (tokens, word_probabilities) where
+                
+                    tokens: A numpy array of strings where tokens[i] is the token with BOW id i in id2token
+                    word_probabilities: A numpy array of probabilities where word_probabilities[i] is the
+                        probability of the token with BOW id of i occuring in the corpus
+        """
+        # The BOW ids and indices into corpus_wide_word_counts are the same
+        num_words = len(id2token)
+        corpus_wide_word_counts = np.zeros(num_words)
+
+        for bow_doc in bow_corpus:
+            for bow_tup in bow_doc:
+                bow_id = bow_tup[0]
+                bow_num_occurrences = bow_tup[1]
+
+                corpus_wide_word_counts[bow_id] += bow_num_occurrences
+
+
+        sum_corpus_word_count = np.sum(corpus_wide_word_counts)
+
+        # Perform additive smoothing to avoid zero-probabilities
+        word_probabilities = np.array([(count + mu) / (sum_corpus_word_count + mu*num_words) for count in corpus_wide_word_counts])
+        
+
+        tokens = np.array([id2token[idx] for idx in np.arange(num_words)])
+        return (tokens, word_probabilities)
+
+    # Return a tuple of (sorted_tokens, word_probs_of_sorted_tokens), sorting
+    #   by descending probabilities
+    @classmethod
+    def sort_tokens_by_probability(cls, tokens, word_probs):
+        sorted_order = word_probs.argsort()[::-1]
+        return (tokens[sorted_order], word_probs[sorted_order])
+
+    @classmethod
+    def determine_downage_categories(cls, corpus_bow, machine_of_comment, id2token, num_categories, alpha, mu=0.0001):
+        """Determine the downage categories for each machine
+        
+           To determine downage categories for machine M, we partition the corpus into two disjoin corpora:
+            the corpus of comments made for machine M and the corpus of all other comments. 
+           We then compute the probabilities of each token occuring in each corpus independently to have
+            2 "vocabulary distributions"
+           Then we combine the 2 vocabulary distributions into a final vocabulary distribution where
+            the probability of token w is given as:
+            
+                p(w) = p(w, z = M)p(alpha) * p(w, z = notM)p(1-alpha)
+                
+            where p(w, z = M) is the probability of token w being chosen from the vocabulary distribution
+            of the corpus of documents for machine M.
+            
+           The downage categories are the most likely num_categories tokens w.r.t. the final vocabulary distribution
+            
+            
+            Parameters:
+                corpus_bow: The complete corpus in BOW format
+                machine_of_comment: An array of length len(corpus_bow) such that machine_of_comment[i] contains
+                    the machine id (assumed to be numeric and in the range [1, number of total machines] )
+                    that the comment of corpus_bow[i] is associated with. 
+                id2token: A dictionary mapping BOW ids to tokens of the corpus
+                num_categories: The number of downage categories to find for each machine
+                alpha: The probability of choosing the vocabulary distribution for comments made for machine M
+                    alpha > 0.5 -> Favor the vocabulary distribution for comments made for machine M
+                    alpha < 0.5 -> Favor the vocabulary distribution for comments NOT made for machine M
+                    Note that alpha=0.5 does not mean that we treat words from comments for machine M as equally
+                        as words from all other comments (since we compute vocabulary distributions indepenently
+                        for comments for machine M vs all other comments)
+                mu: The psuedocount to use for additive smoothing. Set to 0 for no smoothing
+                
+            Returns: 
+                A numpy array s.t. the i'th element contains a tuple (category_tokens, word_probs) for the machine with 
+                the i'th smallest id where
+                    category_tokens: The tokens associated with the top num_categories downage categories
+                    word_probs: The probabilities in the final vocabulary distribution for each token in category_tokens
+        """
+        
+        # np.unique() already sorts the unique values it finds
+        all_machine_ids = np.unique(machine_of_comment)
+
+        
+        downage_categories = []
+        
+        for M_id in all_machine_ids:
+            # Split corpus based on whether the comments were made for machine M or not
+            M_corpus = np.array(corpus_bow)[machine_of_comment == M_id]
+            notM_corpus = np.array(corpus_bow)[machine_of_comment != M_id]
+            
+            sorted_tokens, sorted_word_probs = DownageCategories._determine_downage_categories_for_machine(
+                M_corpus,
+                notM_corpus,
+                id2token,
+                alpha,
+                mu
+            )
+            
+            downage_categories.append((sorted_tokens[:num_categories], sorted_word_probs[:num_categories]))
+            
+            
+        return np.array(downage_categories)
+            
+
+    @classmethod
+    def _determine_downage_categories_for_machine(cls, M_corpus, notM_corpus, id2token, alpha, mu):
+        """Helper function to return the combined vocabulary distribution, sorted in descending order of probability
+        
+            Parameters:
+                M_corpus: The BOW corpus for all comments made for machine M
+                notM_corpus: The BOW corpus for all comments NOT made for machine M
+                id2token: See determine_downage_categories
+                alpha: See determine_downage_categories
+                mu: See determine_downage_categories
+                
+            Returns:
+                The tuple (sorted_tokens, sorted_word_probs) where
+                    sorted_tokens: All of the tokens of the combined vocabulary distribution, sorted in descending
+                        order of probability
+                    sorted_word_probs: The probabilities for each token in sorted_tokens
+        """
+
+        # Note that tokens_M and token_not_M refer to the same list of tokens since they both use the same id2token
+        tokens_M, word_probs_M = DownageCategories.calculate_word_probabilities(M_corpus, id2token, mu=mu)
+        tokens_not_M, word_probs_not_M = DownageCategories.calculate_word_probabilities(notM_corpus, id2token, mu=mu)
+
+        # Probability of choosing each topic distribution
+        topic_probs = np.array([alpha, (1 - alpha)])
+
+        # A list of lists, where vocabulary_probabilities[i][j] gives the probability
+        #   of choosing token j using topic distribution i
+        #
+        # Note that the inner arrays should be referencing the same vocabulary
+        # (e.g. vocabulary_probabilities[i][j] and vocabulary_probabilities[k][j] 
+        #    contain the probability of selecting the SAME token j from topics i and k, respectively)
+        vocabulary_probabilities = np.array([word_probs_M, word_probs_not_M])
+        combined_vocabulary_probs = topic_probs.dot(vocabulary_probabilities)
+        
+        return DownageCategories.sort_tokens_by_probability(tokens_M, combined_vocabulary_probs)
+

--- a/cs411project/nlp/preprocess_corpus.py
+++ b/cs411project/nlp/preprocess_corpus.py
@@ -1,0 +1,61 @@
+import numpy as np
+from gensim.models.ldamodel import LdaModel
+from gensim.corpora.dictionary import Dictionary
+from gensim.parsing.porter import PorterStemmer
+# Use english stopwords provided in gensim as a baseline for stopword removal
+from gensim.parsing.preprocessing import STOPWORDS, preprocess_string, strip_punctuation, strip_numeric, strip_short
+
+# Bigram detection
+from gensim.models.phrases import Phrases, Phraser
+# The score threshold for determining bigrams (see Phrases class for more info)
+BIGRAM_SCORE_THRESHOLD = 1
+# The minimum number of times a bigram has to occur to be considered a bigram
+BIGRAM_MIN_COUNT = 1
+
+
+class Preprocessing:
+
+    @classmethod
+    def preprocess_corpus(cls, raw_corpus):
+        """Preprocess a corpus for the downage categories
+
+            Parameters:
+                raw_corpus: A list of strings where each string is a document
+
+            Returns:
+                A tuple (dictionary, id2token, corpus_bow) where
+
+                    dictionary: The gensim.corpora.dictionary for the preprocessed corpus
+                    id2token: A python dictionary mapping BOW id to token
+                    corpus_bow: The preprocessed corpus in BOW form, using BOW ids from `dictionary`
+        """
+
+        # Define filters to apply to each word
+        # Make each token lowercase
+        # Remove punctuation
+        # Remove numeric characters
+        # Any token less than 2 characters is removed
+        FILTERS = [(lambda x: x.lower()), strip_punctuation, strip_numeric, (lambda x: strip_short(x, minsize=2))]
+
+        preprocessed_corpus = [[word for word in preprocess_string(doc, FILTERS) if word not in STOPWORDS]
+                      for doc in raw_corpus]
+
+        # Porter stemming
+        # porter = PorterStemmer()
+        # tweet_corpus = [[porter.stem(word) for word in doc] for doc in tweet_corpus]
+
+        # Discover useful bigrams like "hot dog" via mutual information (see https://svn.spraakdata.gu.se/repos/gerlof/pub/www/Docs/npmi-pfd.pdf)
+        # Bigrams will have a _ put between them (so the bigram "hot dog" will be transformed to "hot_dog")
+        phrases = Phrases(preprocessed_corpus, min_count=BIGRAM_MIN_COUNT, threshold=BIGRAM_SCORE_THRESHOLD)
+        tweet_corpus = phrases[preprocessed_corpus]
+
+        dictionary = Dictionary(preprocessed_corpus)
+        dictionary.compactify()
+
+        # So we can convert BOW ids to tokens
+        id2token = {bow_id:token for (token, bow_id) in dictionary.token2id.items()}
+
+        corpus_bow = [dictionary.doc2bow(doc) for doc in preprocessed_corpus]
+        
+        return (dictionary, id2token, corpus_bow)
+

--- a/cs411project/sql/DDL.sql
+++ b/cs411project/sql/DDL.sql
@@ -36,7 +36,7 @@ CREATE TABLE IF NOT EXISTS Machine (
 CREATE TABLE IF NOT EXISTS Comments (
         CommentID INT NOT NULL AUTO_INCREMENT,
         LastModifiedTS TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-        /* TODO: (Mike) change this to a FK to a DownageCategory after Basic Demo*/
+        /* The Downage Category for this Comment */
         Category VARCHAR(50) NOT NULL,
         /* The text comment made by the user */
         CommentText VARCHAR(400) NOT NULL,

--- a/cs411project/sql/DDL.sql
+++ b/cs411project/sql/DDL.sql
@@ -4,6 +4,8 @@ DROP TABLE IF EXISTS Comments;
 DROP TABLE IF EXISTS Hardware;
 DROP TABLE IF EXISTS Machine;
 DROP TABLE IF EXISTS Users;
+DROP TABLE IF EXISTS DownageCategory;
+DROP TABLE IF EXISTS DownageCategoryBatch;
 
 
 CREATE TABLE IF NOT EXISTS Users (
@@ -68,5 +70,23 @@ CREATE TABLE IF NOT EXISTS HeartbeatSequence (
         FOREIGN KEY(NetID) REFERENCES Users(NetID),
         FOREIGN KEY(MachineID) REFERENCES Machine(MachineID),
         PRIMARY KEY(SeqID)
+);
+
+CREATE TABLE IF NOT EXISTS DownageCategoryBatch (
+        BatchID INT NOT NULL AUTO_INCREMENT,
+        CompletedTS TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        PRIMARY KEY(BatchID)
+);
+
+CREATE TABLE IF NOT EXISTS DownageCategory (
+        DownageCategoryID INT NOT NULL AUTO_INCREMENT,
+        BatchID INT NOT NULL,
+        BatchRank INT NOT NULL,
+        CategoryText VARCHAR(128) NOT NULL,
+        /* A NULL MachineID means that this DownageCategory is for lab-wide downage categories */
+        MachineID INT,
+        PRIMARY KEY (DownageCategoryID),
+        FOREIGN KEY(BatchID) REFERENCES DownageCategoryBatch(BatchID),
+        FOREIGN KEY(MachineID) REFERENCES Machine(MachineID)
 );
 

--- a/cs411project/views/downage_category_view.py
+++ b/cs411project/views/downage_category_view.py
@@ -1,0 +1,233 @@
+from flask import g, Flask, request
+from flask.json import jsonify
+from flask.views import MethodView
+import numpy as np
+
+from ..database.entity_serializer import EntitySerializer
+from ..nlp.preprocess_corpus import Preprocessing
+from ..nlp.downage_categories import DownageCategories
+
+import json
+
+# TODO: docstring
+class SimpleDownageCategoryStartBatchView(MethodView):
+
+    # The maximum amount of comments to use for determining downage categories
+    MAX_NUM_COMMENTS_FOR_DOWNAGE_BATCH = 100 
+
+    # Number of downage categories to choose for each batch (or for each machine in each batch
+    #   if doing per-machine downage categories)
+    NUM_DOWNAGE_CATEGORIES = 5
+
+    MU = 0.001
+
+    def post(self):
+         connection  = g.mysql_connection.get_connection()
+         cursor = connection.cursor(prepared=True)
+         # Persist to DB that we are starting a new batch
+         new_batch_query = "INSERT INTO DownageCategoryBatch(BatchID) VALUES (NULL)";
+         cursor.execute(new_batch_query)
+         batch_id = cursor.lastrowid
+
+
+         get_comments_query = "SELECT * FROM Comments ORDER BY LastModifiedTS DESC LIMIT %s"
+         cursor.execute(get_comments_query, (SimpleDownageCategoryStartBatchView.MAX_NUM_COMMENTS_FOR_DOWNAGE_BATCH,))
+         col_names = [x[0] for x in cursor.description]
+         result_as_dicts = list(EntitySerializer.db_entities_to_python(cursor, col_names))
+
+
+
+
+         # Perform some preprocessing on the corpus
+         comment_corpus = [comment['CommentText'] for comment in result_as_dicts]
+         _, id2token, corpus_bow = Preprocessing.preprocess_corpus(comment_corpus)
+
+         # Compute downage categories on a per-lab level as well (in case some machines don't have comments
+         #    yet...those machines can use per-lab downage categories as a fallback)
+         tokens, word_probs = DownageCategories.calculate_word_probabilities(corpus_bow, id2token, SimpleDownageCategoryStartBatchView.MU)
+         sorted_tokens, sorted_word_probs = DownageCategories.sort_tokens_by_probability(tokens, word_probs)
+         lab_wide_downage_categories_tokens = sorted_tokens[:SimpleDownageCategoryStartBatchView.NUM_DOWNAGE_CATEGORIES]
+
+         # TODO: remove after debugging
+         print("===")
+         print(lab_wide_downage_categories_tokens)
+         print("===")
+
+         # Persist lab-wide results to DB
+         lab_wide_downage_insert_query = """
+            INSERT INTO DownageCategory(BatchID, BatchRank, CategoryText, MachineID)
+                VALUES (%s, %s, %s, NULL)
+         """
+
+         for idx, token in enumerate(lab_wide_downage_categories_tokens):
+             batch_rank = idx + 1
+             cursor.execute(lab_wide_downage_insert_query, (batch_id, batch_rank, token))
+
+
+         # Close transaction
+         connection.commit()
+         cursor.close()
+         return jsonify("Success")
+
+
+class SimpleDownageCategoryView(MethodView):
+
+    def get(self):
+         connection  = g.mysql_connection.get_connection()
+         cursor = connection.cursor(prepared=True)
+
+         get_latest_batch_id_query = """
+            SELECT BatchID
+            FROM DownageCategoryBatch
+            WHERE CompletedTS = (SELECT MAX(CompletedTS) FROM DownageCategoryBatch)
+         """
+
+         cursor.execute(get_latest_batch_id_query)
+         batch_id = int(cursor.fetchone()[0])
+
+         get_latest_downage_categories_query = """
+            SELECT * FROM DownageCategory WHERE BatchID = (%s) AND MachineID IS NULL
+         """
+
+         cursor.execute(get_latest_downage_categories_query, (batch_id,))
+         col_names = [x[0] for x in cursor.description]
+         result_as_dicts = list(EntitySerializer.db_entities_to_python(cursor, col_names))
+
+         connection.commit()
+         cursor.close()
+         return jsonify(result_as_dicts)
+
+
+
+# TODO: docstring
+class MixtureModelDownageCategoryStartBatchView(MethodView):
+
+    # The maximum amount of comments to use for determining downage categories
+    MAX_NUM_COMMENTS_FOR_DOWNAGE_BATCH = 100 
+
+    # Number of downage categories to choose for each batch (or for each machine in each batch
+    #   if doing per-machine downage categories)
+    NUM_DOWNAGE_CATEGORIES = 5
+
+    ALPHA = 0.55
+
+    MU = 0.0001
+
+
+    def post(self):
+         connection  = g.mysql_connection.get_connection()
+         cursor = connection.cursor(prepared=True)
+
+
+         # Persist to DB that we are starting a new batch
+         new_batch_query = "INSERT INTO DownageCategoryBatch(BatchID) VALUES (NULL)";
+         cursor.execute(new_batch_query)
+         batch_id = cursor.lastrowid
+
+
+         # Get all the Comments we want to use for the batch
+         get_comments_query = "SELECT * FROM Comments ORDER BY LastModifiedTS DESC LIMIT %s"
+         cursor.execute(get_comments_query, (MixtureModelDownageCategoryStartBatchView.MAX_NUM_COMMENTS_FOR_DOWNAGE_BATCH,))
+         col_names = [x[0] for x in cursor.description]
+         result_as_dicts = list(EntitySerializer.db_entities_to_python(cursor, col_names))
+
+
+         # Compute downage categories on a per-machine level
+         comment_corpus = [comment['CommentText'] for comment in result_as_dicts]
+         machine_of_comments = [comment['MachineID'] for comment in result_as_dicts]
+         sorted_machine_ids = np.unique(machine_of_comments)
+         _, id2token, corpus_bow = Preprocessing.preprocess_corpus(comment_corpus)
+
+         machine_downage_categories = DownageCategories.determine_downage_categories(
+            corpus_bow,
+            machine_of_comments,
+            id2token,
+            MixtureModelDownageCategoryStartBatchView.NUM_DOWNAGE_CATEGORIES,
+            MixtureModelDownageCategoryStartBatchView.ALPHA,
+            MixtureModelDownageCategoryStartBatchView.MU
+         )
+
+         # Persist per-machine results to DB
+         per_machine_downage_insert_query = """
+            INSERT INTO DownageCategory(BatchID, BatchRank, CategoryText, MachineID) 
+                VALUES (%s, %s, %s, %s)
+         """
+         for idx, x in enumerate(machine_downage_categories):
+             sorted_tokens = x[0]
+             machine_id = int(sorted_machine_ids[idx])
+
+             for token_idx, token in enumerate(sorted_tokens):
+                 batch_rank = token_idx + 1
+                 cursor.execute(per_machine_downage_insert_query, (batch_id, batch_rank, token, machine_id))
+
+
+
+         # Compute downage categories on a per-lab level as well (in case some machines don't have comments
+         #    yet...those machines can use per-lab downage categories as a fallback)
+         tokens, word_probs = DownageCategories.calculate_word_probabilities(corpus_bow, id2token, MixtureModelDownageCategoryStartBatchView.MU)
+         sorted_tokens, sorted_word_probs = DownageCategories.sort_tokens_by_probability(tokens, word_probs)
+         lab_wide_downage_categories_tokens = sorted_tokens[:MixtureModelDownageCategoryStartBatchView.NUM_DOWNAGE_CATEGORIES]
+
+
+         # Persist lab-wide results to DB
+         lab_wide_downage_insert_query = """
+            INSERT INTO DownageCategory(BatchID, BatchRank, CategoryText, MachineID)
+                VALUES (%s, %s, %s, NULL)
+         """
+
+         for idx, token in enumerate(lab_wide_downage_categories_tokens):
+             batch_rank = idx + 1
+             cursor.execute(lab_wide_downage_insert_query, (batch_id, batch_rank, token))
+
+
+         # Close transaction
+         connection.commit()
+         cursor.close()
+         return jsonify("Success")
+
+
+class MixtureModelDownageCategoryView(MethodView):
+
+    def get(self, machine_id):
+
+         connection  = g.mysql_connection.get_connection()
+         cursor = connection.cursor(prepared=True)
+
+         # Get latest batch id
+         get_latest_batch_id_query = """
+            SELECT BatchID
+            FROM DownageCategoryBatch
+            WHERE CompletedTS = (SELECT MAX(CompletedTS) FROM DownageCategoryBatch)
+         """
+
+         cursor.execute(get_latest_batch_id_query)
+         batch_id = int(cursor.fetchone()[0])
+
+         get_downage_categories_for_machine_query = """
+            SELECT *
+            FROM DownageCategory
+            WHERE BatchID = %s AND MachineID = %s
+         """
+         cursor.execute(get_downage_categories_for_machine_query, (batch_id, machine_id))
+
+         col_names = [x[0] for x in cursor.description]
+         result_as_dicts = list(EntitySerializer.db_entities_to_python(cursor, col_names))
+
+         # There are no downage categories for this machine, fall back to lab-wide downage categories
+         if len(result_as_dicts) == 0:
+             print("Falling back to downage categories that are lab-wide for same batch id")
+
+             get_downage_categories_for_lab_query = """
+                SELECT *
+                FROM DownageCategory
+                WHERE BatchID = %s AND MachineID IS NULL
+             """
+             cursor.execute(get_downage_categories_for_lab_query, (batch_id,))
+             col_names = [x[0] for x in cursor.description]
+             result_as_dicts = list(EntitySerializer.db_entities_to_python(cursor, col_names))
+
+
+         connection.commit()
+         cursor.close()
+         return jsonify(result_as_dicts)
+

--- a/cs411project/views/downage_category_view.py
+++ b/cs411project/views/downage_category_view.py
@@ -4,6 +4,7 @@ from flask.views import MethodView
 import numpy as np
 
 from ..database.entity_serializer import EntitySerializer
+from ..database.constants import PREBAKED_DOWNAGE_CATEGORY_TEXTS
 from ..nlp.preprocess_corpus import Preprocessing
 from ..nlp.downage_categories import DownageCategories
 
@@ -21,84 +22,97 @@ class SimpleDownageCategoryStartBatchView(MethodView):
     MU = 0.001
 
     def post(self):
-         """Start a batch job to compute and store downage categories in a simple way
+        
+        """Start a batch job to compute and store downage categories in a simple way
 
-            Compute downage categories by computing the probabilities of each token 
-                among the most recent MAX_NUM_COMMENTS_FOR_DOWNAGE_BATCH comments updated
-                across the entire lab, and then selecting the top NUM_DOWNAGE_CATEGORIES
-                tokens as the downage categories
-         """
-         connection  = g.mysql_connection.get_connection()
-         cursor = connection.cursor(prepared=True)
-         # Persist to DB that we are starting a new batch
-         new_batch_query = "INSERT INTO DownageCategoryBatch(BatchID) VALUES (NULL)";
-         cursor.execute(new_batch_query)
-         batch_id = cursor.lastrowid
-
-
-         get_comments_query = "SELECT * FROM Comments ORDER BY LastModifiedTS DESC LIMIT %s"
-         cursor.execute(get_comments_query, (SimpleDownageCategoryStartBatchView.MAX_NUM_COMMENTS_FOR_DOWNAGE_BATCH,))
-         col_names = [x[0] for x in cursor.description]
-         result_as_dicts = list(EntitySerializer.db_entities_to_python(cursor, col_names))
+           Compute downage categories by computing the probabilities of each token 
+               among the most recent MAX_NUM_COMMENTS_FOR_DOWNAGE_BATCH comments updated
+               across the entire lab, and then selecting the top NUM_DOWNAGE_CATEGORIES
+               tokens as the downage categories
+        """
+        connection  = g.mysql_connection.get_connection()
+        cursor = connection.cursor(prepared=True)
+        # Persist to DB that we are starting a new batch
+        new_batch_query = "INSERT INTO DownageCategoryBatch(BatchID) VALUES (NULL)";
+        cursor.execute(new_batch_query)
+        batch_id = cursor.lastrowid
 
 
+        get_comments_query = "SELECT * FROM Comments ORDER BY LastModifiedTS DESC LIMIT %s"
+        cursor.execute(get_comments_query, (SimpleDownageCategoryStartBatchView.MAX_NUM_COMMENTS_FOR_DOWNAGE_BATCH,))
+        col_names = [x[0] for x in cursor.description]
+        result_as_dicts = list(EntitySerializer.db_entities_to_python(cursor, col_names))
 
 
-         # Perform some preprocessing on the corpus
-         comment_corpus = [comment['CommentText'] for comment in result_as_dicts]
-         _, id2token, corpus_bow = Preprocessing.preprocess_corpus(comment_corpus)
-
-         # Compute downage categories on a per-lab level as well (in case some machines don't have comments
-         #    yet...those machines can use per-lab downage categories as a fallback)
-         tokens, word_probs = DownageCategories.calculate_word_probabilities(corpus_bow, id2token, SimpleDownageCategoryStartBatchView.MU)
-         sorted_tokens, sorted_word_probs = DownageCategories.sort_tokens_by_probability(tokens, word_probs)
-         lab_wide_downage_categories_tokens = sorted_tokens[:SimpleDownageCategoryStartBatchView.NUM_DOWNAGE_CATEGORIES]
-
-         # Persist lab-wide results to DB, using a NULL MachineID to indicate lab-wide downage categories
-         lab_wide_downage_insert_query = """
-            INSERT INTO DownageCategory(BatchID, BatchRank, CategoryText, MachineID)
-                VALUES (%s, %s, %s, NULL)
-         """
-
-         for idx, token in enumerate(lab_wide_downage_categories_tokens):
-             batch_rank = idx + 1
-             cursor.execute(lab_wide_downage_insert_query, (batch_id, batch_rank, token))
 
 
-         # Close transaction
-         connection.commit()
-         cursor.close()
-         return jsonify("Success")
+        # Perform some preprocessing on the corpus
+        comment_corpus = [comment['CommentText'] for comment in result_as_dicts]
+        _, id2token, corpus_bow = Preprocessing.preprocess_corpus(comment_corpus)
+
+        # Compute downage categories on a per-lab level as well (in case some machines don't have comments
+        #    yet...those machines can use per-lab downage categories as a fallback)
+        tokens, word_probs = DownageCategories.calculate_word_probabilities(corpus_bow, id2token, SimpleDownageCategoryStartBatchView.MU)
+        sorted_tokens, sorted_word_probs = DownageCategories.sort_tokens_by_probability(tokens, word_probs)
+        lab_wide_downage_categories_tokens = sorted_tokens[:SimpleDownageCategoryStartBatchView.NUM_DOWNAGE_CATEGORIES]
+
+        # Persist lab-wide results to DB, using a NULL MachineID to indicate lab-wide downage categories
+        lab_wide_downage_insert_query = """
+           INSERT INTO DownageCategory(BatchID, BatchRank, CategoryText, MachineID)
+               VALUES (%s, %s, %s, NULL)
+        """
+
+        for idx, token in enumerate(lab_wide_downage_categories_tokens):
+            batch_rank = idx + 1
+            cursor.execute(lab_wide_downage_insert_query, (batch_id, batch_rank, token))
+
+
+        # Close transaction
+        connection.commit()
+        cursor.close()
+        return jsonify("Success")
 
 
 class SimpleDownageCategoryView(MethodView):
 
     def get(self):
-         """Get the lab-wide downage categories
-         """
-         connection  = g.mysql_connection.get_connection()
-         cursor = connection.cursor(prepared=True)
+        """Get the lab-wide downage categories
+        """
+        connection  = g.mysql_connection.get_connection()
 
-         get_latest_batch_id_query = """
-            SELECT BatchID
-            FROM DownageCategoryBatch
-            WHERE CompletedTS = (SELECT MAX(CompletedTS) FROM DownageCategoryBatch)
-         """
+        result_as_dicts = SimpleDownageCategoryView.get_simple_downage_categories(connection)
 
-         cursor.execute(get_latest_batch_id_query)
-         batch_id = int(cursor.fetchone()[0])
+        connection.commit()
+        return jsonify(result_as_dicts)
 
-         get_latest_downage_categories_query = """
-            SELECT * FROM DownageCategory WHERE BatchID = (%s) AND MachineID IS NULL
-         """
+    @classmethod
+    def get_simple_downage_categories(cls, connection):
+        """Get the 'simple' downage categories from the DB
 
-         cursor.execute(get_latest_downage_categories_query, (batch_id,))
-         col_names = [x[0] for x in cursor.description]
-         result_as_dicts = list(EntitySerializer.db_entities_to_python(cursor, col_names))
+           Caller must call .commit() on the connection
+        """
+        cursor = connection.cursor(prepared=True)
 
-         connection.commit()
-         cursor.close()
-         return jsonify(result_as_dicts)
+        get_latest_batch_id_query = """
+           SELECT BatchID
+           FROM DownageCategoryBatch
+           WHERE CompletedTS = (SELECT MAX(CompletedTS) FROM DownageCategoryBatch)
+        """
+
+        cursor.execute(get_latest_batch_id_query)
+        batch_id = int(cursor.fetchone()[0])
+
+        get_latest_downage_categories_query = """
+           SELECT * FROM DownageCategory WHERE BatchID = (%s) AND MachineID IS NULL
+        """
+
+        cursor.execute(get_latest_downage_categories_query, (batch_id,))
+        col_names = [x[0] for x in cursor.description]
+        result_as_dicts = list(EntitySerializer.db_entities_to_python(cursor, col_names))
+
+        cursor.close()
+
+        return result_as_dicts
 
 
 
@@ -117,145 +131,216 @@ class MixtureModelDownageCategoryStartBatchView(MethodView):
 
 
     def post(self):
-         """Start a batch job to compute the downage categories using a simple mixture model
+        """Start a batch job to compute the downage categories using a simple mixture model
 
-            This endpoint also computes the downage categories in the same way as SimpleDownageCategoryStartBatchView,
-                persisting them under the same BatchID as the mixture model downage categories
-                with MachineID set to NULL
+           This endpoint also computes the downage categories in the same way as SimpleDownageCategoryStartBatchView,
+               persisting them under the same BatchID as the mixture model downage categories
+               with MachineID set to NULL
 
-            Grabs the MAX_NUM_COMMENTS_FOR_DOWNAGE_BATCH most recently updated comments
-                across the lab as our input corpus, then splits that input corpus into
-                comments made for machine M vs all other comments...for every machine M
-                that has at least one comment in the input corpus
+           Grabs the MAX_NUM_COMMENTS_FOR_DOWNAGE_BATCH most recently updated comments
+               across the lab as our input corpus, then splits that input corpus into
+               comments made for machine M vs all other comments...for every machine M
+               that has at least one comment in the input corpus
 
-            If there are no comments for a given machine M within the input corpus,
-                then no downage categories are computed for that machine. Retrieving
-                the downage categories for M will resort to falling back to the
-                "simple" downage categories as they are computed in SimpleDownageCategoryStartBatchView
+           If there are no comments for a given machine M within the input corpus,
+               then no downage categories are computed for that machine. Retrieving
+               the downage categories for M will resort to falling back to the
+               "simple" downage categories as they are computed in SimpleDownageCategoryStartBatchView
 
-            See nlp.determine_downage_categories() for an explanation on how downage categories
-                are computed
-         """
-         connection  = g.mysql_connection.get_connection()
-         cursor = connection.cursor(prepared=True)
-
-
-         # Persist to DB that we are starting a new batch
-         new_batch_query = "INSERT INTO DownageCategoryBatch(BatchID) VALUES (NULL)";
-         cursor.execute(new_batch_query)
-         batch_id = cursor.lastrowid
+           See nlp.determine_downage_categories() for an explanation on how downage categories
+               are computed
+        """
+        connection  = g.mysql_connection.get_connection()
+        cursor = connection.cursor(prepared=True)
 
 
-         # Get all the Comments we want to use for the batch
-         get_comments_query = "SELECT * FROM Comments ORDER BY LastModifiedTS DESC LIMIT %s"
-         cursor.execute(get_comments_query, (MixtureModelDownageCategoryStartBatchView.MAX_NUM_COMMENTS_FOR_DOWNAGE_BATCH,))
-         col_names = [x[0] for x in cursor.description]
-         result_as_dicts = list(EntitySerializer.db_entities_to_python(cursor, col_names))
+        # Persist to DB that we are starting a new batch
+        new_batch_query = "INSERT INTO DownageCategoryBatch(BatchID) VALUES (NULL)";
+        cursor.execute(new_batch_query)
+        batch_id = cursor.lastrowid
 
 
-         # Compute downage categories on a per-machine level
-         comment_corpus = [comment['CommentText'] for comment in result_as_dicts]
-         machine_of_comments = [comment['MachineID'] for comment in result_as_dicts]
-         sorted_machine_ids = np.unique(machine_of_comments)
-         _, id2token, corpus_bow = Preprocessing.preprocess_corpus(comment_corpus)
+        # Get all the Comments we want to use for the batch
+        get_comments_query = "SELECT * FROM Comments ORDER BY LastModifiedTS DESC LIMIT %s"
+        cursor.execute(get_comments_query, (MixtureModelDownageCategoryStartBatchView.MAX_NUM_COMMENTS_FOR_DOWNAGE_BATCH,))
+        col_names = [x[0] for x in cursor.description]
+        result_as_dicts = list(EntitySerializer.db_entities_to_python(cursor, col_names))
 
-         machine_downage_categories = DownageCategories.determine_downage_categories(
+
+        # Compute downage categories on a per-machine level
+        comment_corpus = [comment['CommentText'] for comment in result_as_dicts]
+        machine_of_comments = [comment['MachineID'] for comment in result_as_dicts]
+        sorted_machine_ids = np.unique(machine_of_comments)
+        _, id2token, corpus_bow = Preprocessing.preprocess_corpus(comment_corpus)
+
+        machine_downage_categories = DownageCategories.determine_downage_categories(
             corpus_bow,
             machine_of_comments,
             id2token,
             MixtureModelDownageCategoryStartBatchView.NUM_DOWNAGE_CATEGORIES,
             MixtureModelDownageCategoryStartBatchView.ALPHA,
             MixtureModelDownageCategoryStartBatchView.MU
-         )
+        )
 
-         # Persist per-machine results to DB
-         per_machine_downage_insert_query = """
-            INSERT INTO DownageCategory(BatchID, BatchRank, CategoryText, MachineID) 
-                VALUES (%s, %s, %s, %s)
-         """
-         for idx, x in enumerate(machine_downage_categories):
-             sorted_tokens = x[0]
-             machine_id = int(sorted_machine_ids[idx])
+        # Persist per-machine results to DB
+        per_machine_downage_insert_query = """
+           INSERT INTO DownageCategory(BatchID, BatchRank, CategoryText, MachineID) 
+               VALUES (%s, %s, %s, %s)
+        """
+        for idx, x in enumerate(machine_downage_categories):
+            sorted_tokens = x[0]
+            machine_id = int(sorted_machine_ids[idx])
 
-             for token_idx, token in enumerate(sorted_tokens):
-                 batch_rank = token_idx + 1
-                 cursor.execute(per_machine_downage_insert_query, (batch_id, batch_rank, token, machine_id))
-
-
-
-         # Compute downage categories on a per-lab level as well (in case some machines don't have comments
-         #    yet...those machines can use per-lab downage categories as a fallback)
-         tokens, word_probs = DownageCategories.calculate_word_probabilities(corpus_bow, id2token, MixtureModelDownageCategoryStartBatchView.MU)
-         sorted_tokens, sorted_word_probs = DownageCategories.sort_tokens_by_probability(tokens, word_probs)
-         lab_wide_downage_categories_tokens = sorted_tokens[:MixtureModelDownageCategoryStartBatchView.NUM_DOWNAGE_CATEGORIES]
+            for token_idx, token in enumerate(sorted_tokens):
+                batch_rank = token_idx + 1
+                cursor.execute(per_machine_downage_insert_query, (batch_id, batch_rank, token, machine_id))
 
 
-         # Persist lab-wide results to DB, using a NULL MachineID to indicate lab-wide downage categories
-         lab_wide_downage_insert_query = """
-            INSERT INTO DownageCategory(BatchID, BatchRank, CategoryText, MachineID)
-                VALUES (%s, %s, %s, NULL)
-         """
 
-         for idx, token in enumerate(lab_wide_downage_categories_tokens):
-             batch_rank = idx + 1
-             cursor.execute(lab_wide_downage_insert_query, (batch_id, batch_rank, token))
+        # Compute downage categories on a per-lab level as well (in case some machines don't have comments
+        #    yet...those machines can use per-lab downage categories as a fallback)
+        tokens, word_probs = DownageCategories.calculate_word_probabilities(corpus_bow, id2token, MixtureModelDownageCategoryStartBatchView.MU)
+        sorted_tokens, sorted_word_probs = DownageCategories.sort_tokens_by_probability(tokens, word_probs)
+        lab_wide_downage_categories_tokens = sorted_tokens[:MixtureModelDownageCategoryStartBatchView.NUM_DOWNAGE_CATEGORIES]
 
 
-         # Close transaction
-         connection.commit()
-         cursor.close()
-         return jsonify("Success")
+        # Persist lab-wide results to DB, using a NULL MachineID to indicate lab-wide downage categories
+        lab_wide_downage_insert_query = """
+           INSERT INTO DownageCategory(BatchID, BatchRank, CategoryText, MachineID)
+               VALUES (%s, %s, %s, NULL)
+        """
+
+        for idx, token in enumerate(lab_wide_downage_categories_tokens):
+            batch_rank = idx + 1
+            cursor.execute(lab_wide_downage_insert_query, (batch_id, batch_rank, token))
+
+
+        # Close transaction
+        connection.commit()
+        cursor.close()
+        return jsonify("Success")
 
 
 class MixtureModelDownageCategoryView(MethodView):
 
     def get(self, machine_id):
-         """Get the downage categories for machine machine_id from the most recently persisted downage category batch
 
-            Note that if there were no downage categories computed for the machine with id machine_id
-                (non-existent machine_id, or the specified machine had 0 comments in the input corpus
-                for MixtureModelDownageCategoryStartBatchView), then this endpoint will return
-                the "simple" downage categories as specified in SimpleDownageCategoryStartBatchView
-         """
+        """Get the downage categories for machine machine_id from the most recently persisted downage category batch
 
-         connection  = g.mysql_connection.get_connection()
-         cursor = connection.cursor(prepared=True)
+           Note that if there were no downage categories computed for the machine with id machine_id
+               (non-existent machine_id, or the specified machine had 0 comments in the input corpus
+               for MixtureModelDownageCategoryStartBatchView), then this endpoint will return
+               the "simple" downage categories as specified in SimpleDownageCategoryStartBatchView
+        """
 
-         # Get latest batch id
-         get_latest_batch_id_query = """
-            SELECT BatchID
-            FROM DownageCategoryBatch
-            WHERE CompletedTS = (SELECT MAX(CompletedTS) FROM DownageCategoryBatch)
-         """
+        connection  = g.mysql_connection.get_connection()
 
-         cursor.execute(get_latest_batch_id_query)
-         batch_id = int(cursor.fetchone()[0])
+        result_as_dicts = MixtureModelDownageCategoryView.get_downage_categories_for_machine(connection, machine_id)
 
-         get_downage_categories_for_machine_query = """
-            SELECT *
-            FROM DownageCategory
-            WHERE BatchID = %s AND MachineID = %s
-         """
-         cursor.execute(get_downage_categories_for_machine_query, (batch_id, machine_id))
+        connection.commit()
+        return jsonify(result_as_dicts)
 
-         col_names = [x[0] for x in cursor.description]
-         result_as_dicts = list(EntitySerializer.db_entities_to_python(cursor, col_names))
+    @classmethod
+    def get_downage_categories_for_machine(cls, connection, machine_id):
+        """Get the downage categories for a given machine, falling back to lab-wide 'simple' downage categories if needed
 
-         # There are no downage categories for this machine, fall back to lab-wide downage categories
-         if len(result_as_dicts) == 0:
-             print("Falling back to downage categories that are lab-wide for same batch id")
+            Caller must call .commit() on the connection
+        """
 
-             get_downage_categories_for_lab_query = """
-                SELECT *
-                FROM DownageCategory
-                WHERE BatchID = %s AND MachineID IS NULL
-             """
-             cursor.execute(get_downage_categories_for_lab_query, (batch_id,))
-             col_names = [x[0] for x in cursor.description]
-             result_as_dicts = list(EntitySerializer.db_entities_to_python(cursor, col_names))
+        cursor = connection.cursor(prepared=True)
+
+        # Get latest batch id
+        get_latest_batch_id_query = """
+           SELECT BatchID
+           FROM DownageCategoryBatch
+           WHERE CompletedTS = (SELECT MAX(CompletedTS) FROM DownageCategoryBatch)
+        """
+
+        cursor.execute(get_latest_batch_id_query)
+        batch_id = int(cursor.fetchone()[0])
+
+        get_downage_categories_for_machine_query = """
+           SELECT *
+           FROM DownageCategory
+           WHERE BatchID = %s AND MachineID = %s
+        """
+        cursor.execute(get_downage_categories_for_machine_query, (batch_id, machine_id))
+
+        col_names = [x[0] for x in cursor.description]
+        result_as_dicts = list(EntitySerializer.db_entities_to_python(cursor, col_names))
+
+        # There are no downage categories for this machine, fall back to lab-wide downage categories
+        if len(result_as_dicts) == 0:
+            print("Falling back to downage categories that are lab-wide for same batch id")
+
+            result_as_dicts = SimpleDownageCategoryView.get_simple_downage_categories(connection)
+
+        cursor.close()
+
+        return result_as_dicts
 
 
-         connection.commit()
-         cursor.close()
-         return jsonify(result_as_dicts)
+class DownageCategoriesEditingExistingCommentView(MethodView):
+
+    def get(self, comment_id):
+        """Returns the downage categories available for an existing comment
+
+           The union of the following sets for comment C with id comment_id:
+            * DownageCategories for the machine M that C is associated with
+            * The prebaked downage categories
+            * The existing category for C
+
+           The results are returned in a list of JSON objects with 
+            the schema of DownageCategory relation (with some fields
+            set to NULL if we cannot determine them (e.g. BatchID for the prebaked downage categories))
+        """
+        connection = g.mysql_connection.get_connection()
+        result_as_dicts = DownageCategoriesEditingExistingCommentView.get_downage_categories_for_editing_comment(connection, comment_id)
+        connection.close()
+        return jsonify(result_as_dicts)
+
+    @classmethod
+    def get_downage_categories_for_editing_comment(cls, connection, comment_id):
+        """Get the downage categories needed for editing a comment
+        """
+        
+        cursor = connection.cursor(prepared=True)
+
+        
+        get_machine_id_of_comment_query = """
+            SELECT MachineID, Category FROM Comments WHERE CommentID = %s
+        """
+        cursor.execute(get_machine_id_of_comment_query, (comment_id,))
+        row = cursor.fetchone()
+        machine_id = int(row[0])
+        existing_comment_category = row[1]
+        computed_downage_categories_dicts = MixtureModelDownageCategoryView.get_downage_categories_for_machine(connection, machine_id)
+
+
+        scalar_downage_categories = [x for x in PREBAKED_DOWNAGE_CATEGORY_TEXTS]
+        scalar_downage_categories.append(existing_comment_category)
+
+        # Combine the downage category of comment C, the prebaked downage categories, and downage categories for machine M
+        #   s.t. each element in the resulting list is a dictionary with the same keys, but None for any values
+        #   that cannot be inferred from the scalar category texts of C's existing downage category and the prebaked 
+        #   downage categories
+        result_as_dicts = [x for x in computed_downage_categories_dicts]
+        for category_text in scalar_downage_categories:
+            # Keys taken from DDL for DownageCategory
+            result_as_dicts.append({
+                'DownageCategoryID': None,
+                'BatchID': None,
+                'BatchRank': None,
+                'CategoryText': category_text,
+                'MachineID': None
+            })
+
+        return result_as_dicts
+
+
+        
+        
+
+        
+
 


### PR DESCRIPTION
# Overall Goal
Utilize gensim to do some basic text preprocessing and discover "downage categories" as the most popular unigrams/bigrams found within the most recently updated k comments (k is configurable via a Python constant). 2 methods of generating/retrieving downage categories are exposed, using the k comments as the input corpus:

1. "Simple" downage categories. For this we simply count the number of times each token occurs in the input corpus and return the NUM_CATEGORIES tokens with the highest probability. "Simple" downage categories are lab-wide
2. "mixture" downage categories. For this we give more emphasis to tokens found in comments for machine M vs words found in other comments. See nlp/downage_categories.py for more explanation. We can tweak the weight we give to tokens from comments of machine M

## Routes
POST project/downage-category/simple
- Generate the simple downage categories based on the current comments

GET project/downage-category/simple
- Read a the top DownageCategory entities generated in the last batch run to generate downage categories

POST project/downage-category/mixture
- Generate the mixture downgae categories (as well as the simple downage categories) based on the current comments

GET project/downage-category/mixture/<machine_id>
- Read the DownageCategory entities generated during the last batch run to generate downage categories
- If no such DownageCategory entites exist for Machine machine_id, fallback to the 'simple' downage categories generated in the last batch run

GET project/downage-category/editing-comment/<comment_id>
- Retrieve the downage categories appropriate for editing the Comment C with id comment_id (namely, the current category for C, the prebaked categories, and the downage categories associated with the machine M that C is referring to that were generated in the last batch run...falling back to the 'simple' downage categories if no mixture downage categories exist for machine M in the last batch run)
- All JSON objects in the returned list have the same schema, but the JSON objects for C's current category and the prebaked downage categories have null for every field except 'CategoryText' (since we did not extract that information from the DownageCategory relation)

## DDL Changes

Added DownageCategoryBatch, an entity to mark when a batch of downage categories was last calculated (used to figure out the last batch we ran)

Added DownageCategory, an entity to represent a **discovered** downage category. Note that if MachineID is NULL, then this DownageCategory is a 'simple' downage category (otherwise it is a downage category from the mixture categories and is associated with a specific machine). The BatchRank indicates the rank of that DownageCategory w.r.t all DownageCategories with the same BatchID AND MachineID. Basically, we can use BatchRank to present a ranked list of downage categories for a user in order of probability.

## Tests
I tested this code manually on my laptop and on cPanel. This PR is currently deployed on mike-dev on cPanel at time of writing.



